### PR TITLE
Move css-loader to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@angular/router": "3.1.0",
     "base64id": "0.1.0",
     "core-js": "2.4.1",
-    "css-loader": "0.15.5",
     "lodash": "3.10.1",
     "moment": "2.10.6",
     "optimist": "0.6.1",
@@ -41,6 +40,7 @@
   "devDependencies": {
     "bootstrap-sass": "3.3.5",
     "chunk-manifest-webpack-plugin": "0.0.1",
+    "css-loader": "0.15.5",
     "exports-loader": "0.6.2",
     "expose-loader": "0.7.1",
     "extract-text-webpack-plugin": "0.8.2",


### PR DESCRIPTION
Shouldn't `css-loader` be placed in `devDependencies`, along with other loaders and webpack? Now it's a part of `dependencies`. 