### PR TITLE
Fixes TSLint for observables

### DIFF
--- a/src/app/thread/threads.service.ts
+++ b/src/app/thread/threads.service.ts
@@ -7,7 +7,6 @@ import * as _ from 'lodash';
 
 @Injectable()
 export class ThreadsService {
-
   // `threads` is a observable that contains the most up to date list of threads
   threads: Observable<{ [key: string]: Thread }>;
 
@@ -15,54 +14,59 @@ export class ThreadsService {
   orderedThreads: Observable<Thread[]>;
 
   // `currentThread` contains the currently selected thread
-  currentThread: Subject<Thread> =
-    new BehaviorSubject<Thread>(new Thread());
+  currentThread: Subject<Thread> = new BehaviorSubject<Thread>(new Thread());
 
   // `currentThreadMessages` contains the set of messages for the currently
   // selected thread
   currentThreadMessages: Observable<Message[]>;
 
   constructor(public messagesService: MessagesService) {
+    this.threads = messagesService.messages.map((messages: Message[]) => {
+      const threads: { [key: string]: Thread } = {};
+      // Store the message's thread in our accumulator `threads`
+      messages.map((message: Message) => {
+        threads[message.thread.id] =
+          threads[message.thread.id] || message.thread;
 
-    this.threads = messagesService.messages
-      .map( (messages: Message[]) => {
-        const threads: {[key: string]: Thread} = {};
-        // Store the message's thread in our accumulator `threads`
-        messages.map((message: Message) => {
-          threads[message.thread.id] = threads[message.thread.id] ||
-            message.thread;
-
-          // Cache the most recent message for each thread
-          const messagesThread: Thread = threads[message.thread.id];
-          if (!messagesThread.lastMessage ||
-              messagesThread.lastMessage.sentAt < message.sentAt) {
-            messagesThread.lastMessage = message;
-          }
-        });
-        return threads;
-      });
-
-    this.orderedThreads = this.threads
-      .map((threadGroups: { [key: string]: Thread }) => {
-        const threads: Thread[] = _.values(threadGroups);
-        return _.sortBy(threads, (t: Thread) => t.lastMessage.sentAt).reverse();
-      });
-
-    this.currentThreadMessages = this.currentThread
-      .combineLatest(messagesService.messages,
-                     (currentThread: Thread, messages: Message[]) => {
-        if (currentThread && messages.length > 0) {
-          return _.chain(messages)
-            .filter((message: Message) =>
-                    (message.thread.id === currentThread.id))
-            .map((message: Message) => {
-              message.isRead = true;
-              return message; })
-            .value();
-        } else {
-          return [];
+        // Cache the most recent message for each thread
+        const messagesThread: Thread = threads[message.thread.id];
+        if (
+          !messagesThread.lastMessage ||
+          messagesThread.lastMessage.sentAt < message.sentAt
+        ) {
+          messagesThread.lastMessage = message;
         }
       });
+      return threads;
+    });
+
+    this.orderedThreads = this.threads.map(
+      (threadGroups: { [key: string]: Thread }) => {
+        const threads: Thread[] = _.values(threadGroups);
+        return _.sortBy(threads, (t: Thread) => t.lastMessage.sentAt).reverse();
+      }
+    );
+
+    this.currentThreadMessages = this.currentThread
+      .asObservable()
+      .combineLatest(
+        messagesService.messages,
+        (currentThread: Thread, messages: Message[]) => {
+          if (currentThread && messages.length > 0) {
+            return _.chain(messages)
+              .filter(
+                (message: Message) => message.thread.id === currentThread.id
+              )
+              .map((message: Message) => {
+                message.isRead = true;
+                return message;
+              })
+              .value();
+          } else {
+            return [];
+          }
+        }
+      );
 
     this.currentThread.subscribe(this.messagesService.markThreadAsRead);
   }
@@ -70,9 +74,6 @@ export class ThreadsService {
   setCurrentThread(newThread: Thread): void {
     this.currentThread.next(newThread);
   }
-
 }
 
-export const threadsServiceInjectables: Array<any> = [
-  ThreadsService
-];
+export const threadsServiceInjectables: Array<any> = [ThreadsService];


### PR DESCRIPTION
#53 
This PR fixes the lint issue when we directly use observable operators on a subject.

It should not change the behaviour of it's consumers.